### PR TITLE
Add missing jar when hosting authentication endpoint externally

### DIFF
--- a/host-endpoints-externally/setup-authentication-endpoint.sh
+++ b/host-endpoints-externally/setup-authentication-endpoint.sh
@@ -91,6 +91,7 @@ cp $IS_HOME/repository/components/plugins/org.wso2.carbon.identity.oauth_*.jar $
 cp $IS_HOME/repository/components/plugins/org.wso2.carbon.extension.identity.authenticator.backupcode.connector_*.jar $WEB_APP_LIB
 cp $IS_HOME/repository/components/plugins/org.wso2.carbon.identity.application.authentication.framework_*.jar $WEB_APP_LIB
 cp $IS_HOME/lib/runtimes/cxf3/org.wso2.carbon.identity.application.authentication.endpoint.util-*.jar $WEB_APP_LIB
+cp $IS_HOME/lib/runtimes/cxf3/org.wso2.carbon.identity.mgt.endpoint.util-*.jar $WEB_APP_LIB
 cp $IS_HOME/repository/components/plugins/jettison_*.jar $WEB_APP_LIB
 cp $IS_HOME/lib/runtimes/cxf3/javax.ws.rs-api-*.jar $WEB_APP_LIB
 cp $IS_HOME/lib/runtimes/cxf3/cxf-core-*.jar $WEB_APP_LIB


### PR DESCRIPTION
## Purpose
>  $subject

### Related Issues
- https://github.com/wso2/product-is/issues/15721

As described in this issue comment https://github.com/wso2/product-is/issues/15721#issuecomment-1514961506, the `org.wso2.carbon.identity.mgt.endpoint.util` jar file has to add into the lib folder of the authenticationednpoint.
